### PR TITLE
flatten: Remove PostgreSQL configuration parameters

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -3,7 +3,9 @@ Reading logs
 
 If logging is configured using a :ref:`default configuration<config-logging>`, then log messages are written to ``info.log`` (and possibly ``debug.log``).
 
-Log messages are formatted as::
+Log messages are formatted as:
+
+.. code-block:: none
 
     %(asctime)s - %(process)d - %(name)s - %(levelname)s - %(message)s
 

--- a/manage.py
+++ b/manage.py
@@ -377,9 +377,6 @@ def _run_collection(name, collection_id):
 
     db = Database()
     db.set_search_path([name, 'public'])
-    db.execute('SET parallel_tuple_cost = 0.00001')
-    db.execute('SET parallel_setup_cost = 0.00001')
-    db.execute("SET work_mem = '10MB'")
     db.execute_values('INSERT INTO field_counts VALUES %s', db.all("""
         /* kingfisher-summarize field-counts */
 

--- a/sql/final/analyze.sql
+++ b/sql/final/analyze.sql
@@ -1,0 +1,2 @@
+-- autovacuum will not have analyzed release_summary before it's needed for field_counts.
+ANALYZE release_summary;


### PR DESCRIPTION
These parameters should be set by the database administrator, not the tool: e.g. work_mem is already higher (80MB) in the PostgreSQL config than in this tool (10MB). Different servers might prefer different values.

For parallel_setup_cost (default 1000), most guidance/experience I've read is that this rarely causes PostgreSQL to prefer a parallel plan.

For parallel_tuple_cost (default 0.1), decreasing it can cause PostgreSQL to prefer a parallel plan. I only did a couple tests with collection IDs 1380 and 1403, with the default and changed settings (0.00001):

```sql
EXPLAIN SELECT
            collection_id,
            release_type,
            path,
            sum(object_property) object_property,
            sum(array_item) array_count,
            count(distinct id) distinct_releases
        FROM
            release_summary
        CROSS JOIN
            flatten(release)
        WHERE
            collection_id = 1403
        GROUP BY collection_id, release_type, path;
```

With either pair of settings, the plan was the same (1380 is not parallel, 1403 is parallel).

@kindly Did you encounter cases where changing the costs changed the plan? Otherwise, I prefer to leave the defaults.