### PR TITLE
manage.py: Add a --filter option to the CLI

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -208,14 +208,14 @@ def validate_schema(ctx, param, value):
 
 def construct_extra_where_clause(cursor, filter_field, filter_value):
     """
-    Returns part of a sql where clause, for given filter parameters.
+    Returns part of a WHERE clause, for the given filter parameters.
 
-    :param str cursor: a pschopg2 database cursor
-    :param str filter_field: a period seperated field name, e.g. "tender.procurementMethod"
+    :param cursor: a psycopg2 database cursor
+    :param str filter_field: a period-separated field name, e.g. "tender.procurementMethod"
     :param str filter_value: the value of the specified field, e.g. "direct"
     """
     path = [f"'{x}'" for x in filter_field.split('.')]
-    sql = 'AND d.data->' + '%s->'*(len(path)-1) + '>%s = %s'
+    sql = 'AND d.data' + '->%s' * (len(path) - 1) + '->>%s = %s'
     escaped_sql = cursor.mogrify(sql, filter_field.split('.') + [filter_value])
     return escaped_sql.decode()
 

--- a/manage.py
+++ b/manage.py
@@ -207,7 +207,7 @@ def validate_schema(ctx, param, value):
     return schema
 
 
-def construct_where_fragment_from_filter(cursor, filter_field, filter_value):
+def construct_where_fragment(cursor, filter_field, filter_value):
     """
     Returns part of a WHERE clause, for the given filter parameters.
 
@@ -219,20 +219,6 @@ def construct_where_fragment_from_filter(cursor, filter_field, filter_value):
     format_string = ' AND d.data' + '->%s' * (len(path) - 1) + '->>%s = %s'
     where_fragment = cursor.mogrify(format_string, path + [filter_value])
     return where_fragment.decode()
-
-
-def construct_where_fragment_from_filters(cursor, filters):
-    """
-    Returns part of a WHERE clause, for the given filters.
-
-    :param cursor: a psycopg2 database cursor
-    :param filters: an iterable of filter_field, filter_value pairs
-    """
-
-    where_fragment = ''
-    for filter_field, filter_value in filters:
-        where_fragment += construct_where_fragment_from_filter(cursor, filter_field, filter_value)
-    return where_fragment
 
 
 @click.group()
@@ -292,7 +278,7 @@ def add(ctx, collections, note, name, tables_only, field_counts_option, field_li
         name = f"collection_{'_'.join(str(_id) for _id in sorted(collections))}"
 
     if filters:
-        where_fragment = construct_where_fragment_from_filters(db.cursor, filters)
+        where_fragment = ''.join(construct_where_fragment(db.cursor, field, value) for field, value in filters)
     else:
         where_fragment = None
 

--- a/manage.py
+++ b/manage.py
@@ -269,7 +269,7 @@ def add(ctx, collections, note, name, tables_only, field_counts_option, field_li
     NOTE is your name and a description of your purpose
     """
     logger = logging.getLogger('ocdskingfisher.summarize.add')
-    logger.info('Arguments: collections=%s note=%s name=%s tables_only=%s filter_tuple=%s',
+    logger.info('Arguments: collections=%s note=%s name=%s tables_only=%s filter=%s',
                 collections, note, name, tables_only, filter_tuple)
 
     if not name:

--- a/manage.py
+++ b/manage.py
@@ -402,7 +402,7 @@ def summary_tables(name, tables_only=False, skip=(), where_fragment=None):
     :param str name: the schema's name
     :param boolean tables_only: whether to create SQL tables instead of SQL views
     :param tuple skip: any SQL files to skip
-    :param str where_fragment: an extra clause to use when selecting the data
+    :param str where_fragment: part of a WHERE clause to use when selecting the data
     """
     logger = logging.getLogger('ocdskingfisher.summarize.summary-tables')
 

--- a/manage.py
+++ b/manage.py
@@ -215,10 +215,10 @@ def construct_where_fragment(cursor, filter_field, filter_value):
     :param str filter_field: a period-separated field name, e.g. "tender.procurementMethod"
     :param str filter_value: the value of the specified field, e.g. "direct"
     """
-    path = [f"'{x}'" for x in filter_field.split('.')]
-    sql = 'AND d.data' + '->%s' * (len(path) - 1) + '->>%s = %s'
-    escaped_sql = cursor.mogrify(sql, filter_field.split('.') + [filter_value])
-    return escaped_sql.decode()
+    path = filter_field.split('.')
+    format_string = 'AND d.data' + '->%s' * (len(path) - 1) + '->>%s = %s'
+    where_fragment = cursor.mogrify(format_string, path + [filter_value])
+    return where_fragment.decode()
 
 
 @click.group()

--- a/sql/middle/release_tmp.sql
+++ b/sql/middle/release_tmp.sql
@@ -25,6 +25,7 @@ WHERE
             summaries.selected_collections
         WHERE
             schema=current_schema())
+        EXTRAWHERECLAUSE
 UNION
 SELECT
     r.id::bigint * 10 + 1 AS id,
@@ -52,6 +53,7 @@ WHERE
             summaries.selected_collections
         WHERE
             schema=current_schema())
+        EXTRAWHERECLAUSE
 UNION
 SELECT
     r.id::bigint * 10 + 2 AS id,
@@ -78,6 +80,7 @@ WHERE
             summaries.selected_collections
         WHERE
             schema=current_schema())
+        EXTRAWHERECLAUSE
 UNION
 SELECT
     (r.id::bigint * 1000000 + (ORDINALITY - 1)) * 10 + 3 AS id,
@@ -108,7 +111,8 @@ WHERE
         FROM
             summaries.selected_collections
         WHERE
-            schema=current_schema());
+            schema=current_schema())
+        EXTRAWHERECLAUSE;
 
 CREATE UNIQUE INDEX tmp_release_summary_id ON tmp_release_summary (id);
 

--- a/sql/middle/release_tmp.sql
+++ b/sql/middle/release_tmp.sql
@@ -25,7 +25,7 @@ WHERE
             summaries.selected_collections
         WHERE
             schema=current_schema())
-        EXTRAWHERECLAUSE
+        --  WHEREFRAGMENT
 UNION
 SELECT
     r.id::bigint * 10 + 1 AS id,
@@ -53,7 +53,7 @@ WHERE
             summaries.selected_collections
         WHERE
             schema=current_schema())
-        EXTRAWHERECLAUSE
+        --  WHEREFRAGMENT
 UNION
 SELECT
     r.id::bigint * 10 + 2 AS id,
@@ -80,7 +80,7 @@ WHERE
             summaries.selected_collections
         WHERE
             schema=current_schema())
-        EXTRAWHERECLAUSE
+        --  WHEREFRAGMENT
 UNION
 SELECT
     (r.id::bigint * 1000000 + (ORDINALITY - 1)) * 10 + 3 AS id,
@@ -112,7 +112,8 @@ WHERE
             summaries.selected_collections
         WHERE
             schema=current_schema())
-        EXTRAWHERECLAUSE;
+        --  WHEREFRAGMENT
+;
 
 CREATE UNIQUE INDEX tmp_release_summary_id ON tmp_release_summary (id);
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,7 +11,7 @@ def noop(*args, **kwargs):
 
 
 @contextmanager
-def fixture(db, collections='1', name=None, tables_only=None, field_counts=True, field_lists=True, filter_tuple=()):
+def fixture(db, collections='1', name=None, tables_only=None, field_counts=True, field_lists=True, filters=()):
     runner = CliRunner()
 
     args = ['add', collections, 'Default']
@@ -25,8 +25,8 @@ def fixture(db, collections='1', name=None, tables_only=None, field_counts=True,
         args.append('--no-field-counts')
     if field_lists:
         args.append('--field-lists')
-    if filter_tuple:
-        args.extend(['--filter', *filter_tuple])
+    for filter_ in filters:
+        args.extend(['--filter', *filter_])
 
     result = runner.invoke(cli, args)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,7 +11,7 @@ def noop(*args, **kwargs):
 
 
 @contextmanager
-def fixture(db, collections='1', name=None, tables_only=None, field_counts=True, field_lists=True):
+def fixture(db, collections='1', name=None, tables_only=None, field_counts=True, field_lists=True, filter_tuple=()):
     runner = CliRunner()
 
     args = ['add', collections, 'Default']
@@ -25,6 +25,8 @@ def fixture(db, collections='1', name=None, tables_only=None, field_counts=True,
         args.append('--no-field-counts')
     if field_lists:
         args.append('--field-lists')
+    if filter_tuple:
+        args.extend(['--filter', *filter_tuple])
 
     result = runner.invoke(cli, args)
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -90,7 +90,7 @@ def test_command_name(kwargs, name, collections, db, caplog):
         assert result.output == ''
         assert_log_records(caplog, command, [
             f'Arguments: collections={collections!r} note=Default name={kwargs.get("name")} tables_only=False '
-            'filter_tuple=()',
+            'filter=()',
             f'Added {name}',
             'Running summary-tables routine',
             'Running field-counts routine',
@@ -313,7 +313,7 @@ def test_command(db, tables_only, field_counts, field_lists, tables, views, filt
         for collection_id in [2, 1]:
             expected.extend([
                 f'Arguments: collections=({collection_id},) note=Default name=None tables_only={tables_only!r} '
-                f'filter_tuple={filter_tuple!r}',
+                f'filter={filter_tuple!r}',
                 f'Added collection_{collection_id}',
                 'Running summary-tables routine',
             ])
@@ -540,7 +540,7 @@ def test_command_filter(db, tables_only, field_counts, field_lists, tables, view
         for collection_id in [2, 1]:
             expected.extend([
                 f'Arguments: collections=({collection_id},) note=Default name=None tables_only={tables_only!r} '
-                f'filter_tuple={filter_tuple!r}',
+                f'filter={filter_tuple!r}',
                 f'Added collection_{collection_id}',
                 'Running summary-tables routine',
             ])

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -6,7 +6,7 @@ import pytest
 from click.testing import CliRunner
 from psycopg2 import sql
 
-from manage import SUMMARIES, cli, construct_extra_where_clause
+from manage import SUMMARIES, cli, construct_where_fragment
 from tests import assert_bad_argument, assert_log_records, assert_log_running, fixture, noop
 
 command = 'add'
@@ -32,14 +32,14 @@ for summary_table in SUMMARIES:
         TABLES.add(f'{summary_table.name}_no_data')
 
 
-def test_construct_extra_where_clause(db):
-    assert construct_extra_where_clause(db.cursor, 'a', 'z') == "AND d.data->>'a' = 'z'"
-    assert construct_extra_where_clause(db.cursor, 'a.b', 'z') == "AND d.data->'a'->>'b' = 'z'"
-    assert construct_extra_where_clause(db.cursor, 'a.b.c', 'z') == "AND d.data->'a'->'b'->>'c' = 'z'"
-    assert construct_extra_where_clause(db.cursor, 'a.b.c.d', 'z') == "AND d.data->'a'->'b'->'c'->>'d' = 'z'"
+def test_construct_where_fragment(db):
+    assert construct_where_fragment(db.cursor, 'a', 'z') == "AND d.data->>'a' = 'z'"
+    assert construct_where_fragment(db.cursor, 'a.b', 'z') == "AND d.data->'a'->>'b' = 'z'"
+    assert construct_where_fragment(db.cursor, 'a.b.c', 'z') == "AND d.data->'a'->'b'->>'c' = 'z'"
+    assert construct_where_fragment(db.cursor, 'a.b.c.d', 'z') == "AND d.data->'a'->'b'->'c'->>'d' = 'z'"
 
-    assert construct_extra_where_clause(db.cursor, 'a.b.c', '') == "AND d.data->'a'->'b'->>'c' = ''"
-    assert construct_extra_where_clause(db.cursor, '', 'z') == "AND d.data->>'' = 'z'"
+    assert construct_where_fragment(db.cursor, 'a.b.c', '') == "AND d.data->'a'->'b'->>'c' = ''"
+    assert construct_where_fragment(db.cursor, '', 'z') == "AND d.data->>'' = 'z'"
 
 
 @pytest.mark.parametrize('collections, message', [

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -6,7 +6,7 @@ import pytest
 from click.testing import CliRunner
 from psycopg2 import sql
 
-from manage import SUMMARIES, cli, construct_where_fragment_from_filter
+from manage import SUMMARIES, cli, construct_where_fragment
 from tests import assert_bad_argument, assert_log_records, assert_log_running, fixture, noop
 
 command = 'add'
@@ -32,14 +32,13 @@ for summary_table in SUMMARIES:
         TABLES.add(f'{summary_table.name}_no_data')
 
 
-def test_construct_where_fragment_from_filter(db):
-    assert construct_where_fragment_from_filter(db.cursor, 'a', 'z') == " AND d.data->>'a' = 'z'"
-    assert construct_where_fragment_from_filter(db.cursor, 'a.b', 'z') == " AND d.data->'a'->>'b' = 'z'"
-    assert construct_where_fragment_from_filter(db.cursor, 'a.b.c', 'z') == " AND d.data->'a'->'b'->>'c' = 'z'"
-    assert construct_where_fragment_from_filter(db.cursor, 'a.b.c.d', 'z') == " AND d.data->'a'->'b'->'c'->>'d' = 'z'"
-
-    assert construct_where_fragment_from_filter(db.cursor, 'a.b.c', '') == " AND d.data->'a'->'b'->>'c' = ''"
-    assert construct_where_fragment_from_filter(db.cursor, '', 'z') == " AND d.data->>'' = 'z'"
+def test_construct_where_fragment(db):
+    assert construct_where_fragment(db.cursor, 'a', 'z') == " AND d.data->>'a' = 'z'"
+    assert construct_where_fragment(db.cursor, 'a.b', 'z') == " AND d.data->'a'->>'b' = 'z'"
+    assert construct_where_fragment(db.cursor, 'a.b.c', 'z') == " AND d.data->'a'->'b'->>'c' = 'z'"
+    assert construct_where_fragment(db.cursor, 'a.b.c.d', 'z') == " AND d.data->'a'->'b'->'c'->>'d' = 'z'"
+    assert construct_where_fragment(db.cursor, 'a.b.c', '') == " AND d.data->'a'->'b'->>'c' = ''"
+    assert construct_where_fragment(db.cursor, '', 'z') == " AND d.data->>'' = 'z'"
 
 
 @pytest.mark.parametrize('collections, message', [


### PR DESCRIPTION
A period separated argument is converted into the a '->' separated clause needed for postgres' JSON.

https://github.com/open-contracting/kingfisher-summarize/issues/190

To do:
- [x] Add more tests that filtering happens as expected